### PR TITLE
Using sqlite3 from standard library instead of pysqlite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-pysqlite

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,6 +1,13 @@
+build_image: drydock/u12pytpls:prod
 python:
-  - "2.7"
+  - 2.6      
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+  - 3.5
+  - pypy
+  - pypy3
 language: python
-install: pip install --use-mirrors -r requirements.txt
 script:
   - python sqliteSample.py

--- a/sqliteSample.py
+++ b/sqliteSample.py
@@ -13,7 +13,7 @@ c.execute('''INSERT INTO foods VALUES ('sandwich', 30.14, 20)''')
 
 c.execute('SELECT * FROM foods')
 
-print c.fetchone()
+print(c.fetchone())
 
 conn.commit()
 conn.close()


### PR DESCRIPTION
fixes https://github.com/shippableSamples/sample_python_sqllite/issues/1
pysqlite doesnot support python 2.6 and 3.x. sqlite3 package supports all pythons.